### PR TITLE
Fixes related lookup inputs

### DIFF
--- a/wpadmin/templates/admin/change_form.html
+++ b/wpadmin/templates/admin/change_form.html
@@ -79,6 +79,26 @@
     </script>
 {% endif %}
 
+{% block admin_change_form_document_ready %}
+    <script type="text/javascript">
+        (function($) {
+            $(document).ready(function() {
+                $('.add-another').click(function(e) {
+                    e.preventDefault();
+                    showAddAnotherPopup(this);
+                });
+                $('.related-lookup').click(function(e) {
+                    e.preventDefault();
+                    showRelatedObjectLookupPopup(this);
+                });
+            {% if adminform and add %}
+                $('form#{{ opts.model_name }}_form :input:visible:enabled:first').focus()
+            {% endif %}
+            });
+        })(django.jQuery);
+    </script>
+{% endblock %}
+
 {# JavaScript for prepopulated fields #}
 {% prepopulated_fields_js %}
 


### PR DESCRIPTION
This fixes a problem with related lookup inputs (raw id widgets). These inputs should open a separate modal window to choose the item and once the user clicks the item it automatically closes and assigns the value in the input of the change_form and wpadmin change_form template don't have this working.

PS. wpadmin v1.7.4 on top of django 1.8.4 (everything works fine except this)
