### PR TITLE
Remove importlib error for django 1.9

### DIFF
--- a/wpadmin/menu/utils.py
+++ b/wpadmin/menu/utils.py
@@ -3,7 +3,12 @@ Menu utilities.
 """
 from fnmatch import fnmatch
 
-from django.utils.importlib import import_module
+try:
+    # Django versions >= 1.9
+    from django.utils.module_loading import import_module
+except ImportError:
+    # Django versions < 1.9
+    from django.utils.importlib import import_module
 from django.core.urlresolvers import reverse
 
 from wpadmin.utils import (


### PR DESCRIPTION
When I was installing wpadmin in djnago 1.9 it was throwing an error regarding importlib, as django 1.9 doesnot contain importlib. So, I have made some changes which remove this error.